### PR TITLE
Adding meta canonical using content_for

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,3 @@ group :test do
 end
 
 gem 'mas-build', '~> 2.0' if ENV['MAS_BUILD']
-

--- a/app/views/feedback/submissions/index.html.erb
+++ b/app/views/feedback/submissions/index.html.erb
@@ -1,5 +1,6 @@
-<% set_meta_tags(title:      t('.meta.title'),
-                 canonical:  t('.meta.canonical')) %>
+<% content_for(:head) do %>
+  <link href="<%= t('.meta.canonical') %>" rel="canonical" />
+<% end %>
 
 <h1><%= t_with_source('.heading') %></h1>
 


### PR DESCRIPTION
Using a content_for to add the canonical tag rather than the meta-tags gem