### PR TITLE
[DEV APPROVED][TP-10128] Fix: Bump ruby in Dockerfile

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM masdevtestregistry.azurecr.io/jenkins/ruby2.2.5:latest
+FROM masdevtestregistry.azurecr.io/jenkins/ruby2.5.3:latest
 MAINTAINER development.team@moneyadviceservice.org.uk
 
 RUN apt-get -qq update > /dev/null && \

--- a/lib/feedback/version.rb
+++ b/lib/feedback/version.rb
@@ -1,3 +1,3 @@
 module Feedback
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end


### PR DESCRIPTION
Fix related with [TP-10128](https://moneyadviceservice.tpondemand.com/entity/10128-upgrade-feedback-repo-to-ruby-253)
Dockerfile was still pointing to ruby 2.2 due my own mistake when
rebasing the Ruby upgrade branch over Jenkins incorporation one (done
with Ruby 2.2).

This breaks the Jenkins build as project requires Ruby 2.5.3 to be
built but environment is using ruby 2.2